### PR TITLE
Static build with extra options for backend linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ workspace
 .idea
 linux
 .artifacts
+build/

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -801,9 +801,7 @@ download "https://git.ffmpeg.org/gitweb/ffmpeg.git/snapshot/553eb0773763798a6b96
   --extra-libs="${EXTRALIBS}" \
   --pkgconfigdir="$WORKSPACE/lib/pkgconfig" \
   --pkg-config-flags="--static" \
-	--prefix="${WORKSPACE}" \
-	--disable-stripping \
-	--enable-debug
+	--prefix="${WORKSPACE}"
 
 if is_mac; then
 	execute dsymutil libavcodec/libavcodec.dylib -o libavcodec.dSYM

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -23,11 +23,11 @@ if [[ ("$(uname -m)" == "arm64") && ("$OSTYPE" == "darwin"*) ]]; then
 fi
 
 is_mac () {
-	if [[ "$OSTYPE" == "darwin"* ]]; then
-		return 0
-	fi
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    return 0
+  fi
 
-	return 1
+  return 1
 }
 
 # read by gcc and cmake
@@ -166,10 +166,10 @@ library_exists() {
 }
 
 set_mac_install_name () {
-	local name="${2:-$1}"
-	if is_mac; then
-		execute install_name_tool -id "${WORKSPACE}/lib/$name" $1
-	fi
+  local name="${2:-$1}"
+  if is_mac; then
+    execute install_name_tool -id "${WORKSPACE}/lib/$name" $1
+  fi
 }
 
 build_done() {
@@ -405,8 +405,8 @@ fi
 CONFIGURE_OPTIONS+=("--enable-openssl")
 
 if build "meson"; then
-	execute pip3 install install meson ninja
-	build_done "meson"
+  execute pip3 install install meson ninja
+  build_done "meson"
 fi
 
 if build "cmake"; then
@@ -521,12 +521,12 @@ fi
 CONFIGURE_OPTIONS+=("--enable-libvidstab")
 
 if build "twolame"; then
-	download "https://downloads.sourceforge.net/twolame/twolame-0.4.0.tar.gz"
-	execute ./configure --prefix="${WORKSPACE}" --enable-static --disable-shared
-	execute make -j $MJOBS
-	execute make install
+  download "https://downloads.sourceforge.net/twolame/twolame-0.4.0.tar.gz"
+  execute ./configure --prefix="${WORKSPACE}" --enable-static --disable-shared
+  execute make -j $MJOBS
+  execute make install
 
-	build_done "twolame"
+  build_done "twolame"
 fi
 CONFIGURE_OPTIONS+=("--enable-libtwolame")
 
@@ -547,25 +547,25 @@ fi
 CONFIGURE_OPTIONS+=("--enable-libaom")
 
 if build "dav1d"; then
-	download "https://code.videolan.org/videolan/dav1d/-/archive/0.7.1/dav1d-0.7.1.tar.gz"
-	make_dir "$PACKAGES"/dav1d_build
-	cd "$PACKAGES"/dav1d_build || exit
-	execute meson --prefix="${WORKSPACE}" --libdir="${WORKSPACE}/lib" --default-library=static ../dav1d-0.7.1
-	execute ninja
-	execute ninja install
+  download "https://code.videolan.org/videolan/dav1d/-/archive/0.7.1/dav1d-0.7.1.tar.gz"
+  make_dir "$PACKAGES"/dav1d_build
+  cd "$PACKAGES"/dav1d_build || exit
+  execute meson --prefix="${WORKSPACE}" --libdir="${WORKSPACE}/lib" --default-library=static ../dav1d-0.7.1
+  execute ninja
+  execute ninja install
 
-	build_done "dav1d"
+  build_done "dav1d"
 fi
 CONFIGURE_OPTIONS+=("--enable-libdav1d")
 
 if build "zimg"; then
-	download "https://github.com/sekrit-twc/zimg/archive/release-3.0.1.tar.gz"
-	execute autoreconf -i
-	execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
-	execute make -j $MJOBS
-	execute make install
+  download "https://github.com/sekrit-twc/zimg/archive/release-3.0.1.tar.gz"
+  execute autoreconf -i
+  execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
+  execute make -j $MJOBS
+  execute make install
 
-	build_done "zimg"
+  build_done "zimg"
 fi
 CONFIGURE_OPTIONS+=("--enable-libzimg")
 
@@ -645,35 +645,35 @@ fi
 CONFIGURE_OPTIONS+=("--enable-libfdk-aac")
 
 if build "shine"; then
-	download "https://github.com/toots/shine/archive/3.1.1.tar.gz" "shine-3.1.1.tar.gz"
-	execute autoreconf -i
-	execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
-	execute make -j $MJOBS
-	execute make install
+  download "https://github.com/toots/shine/archive/3.1.1.tar.gz" "shine-3.1.1.tar.gz"
+  execute autoreconf -i
+  execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
+  execute make -j $MJOBS
+  execute make install
 
-	build_done "shine"
+  build_done "shine"
 fi
 CONFIGURE_OPTIONS+=("--enable-libshine")
 
 if build "soxr"; then
-	download "http://ftp.debian.org/debian/pool/main/libs/libsoxr/libsoxr_0.1.3.orig.tar.xz" "soxr-0.1.3.tar.xz"
-	make_dir build
-	cd build || exit
-	execute cmake .. -DWITH_OPENMP:BOOL=OFF -Wno-dev -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS:BOOL=OFF
-	execute make -j $MJOBS
-	execute make install
+  download "http://ftp.debian.org/debian/pool/main/libs/libsoxr/libsoxr_0.1.3.orig.tar.xz" "soxr-0.1.3.tar.xz"
+  make_dir build
+  cd build || exit
+  execute cmake .. -DWITH_OPENMP:BOOL=OFF -Wno-dev -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS:BOOL=OFF
+  execute make -j $MJOBS
+  execute make install
 
-	build_done "soxr"
+  build_done "soxr"
 fi
 CONFIGURE_OPTIONS+=("--enable-libsoxr")
 
 if build "speex"; then
-	download "http://downloads.us.xiph.org/releases/speex/speex-1.2.0.tar.gz"
-	execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
-	execute make -j $MJOBS
-	execute make install
+  download "http://downloads.us.xiph.org/releases/speex/speex-1.2.0.tar.gz"
+  execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
+  execute make -j $MJOBS
+  execute make install
 
-	build_done "speex"
+  build_done "speex"
 fi
 CONFIGURE_OPTIONS+=("--enable-libspeex")
 
@@ -694,14 +694,14 @@ fi
 CONFIGURE_OPTIONS+=("--enable-libwebp")
 
 if build "openjpeg"; then
-	download "https://github.com/uclouvain/openjpeg/archive/v2.3.1.tar.gz" "openjpeg-v2.3.1.tar.gz"
-	make_dir build
-	cd build || exit
-	execute cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DBUILD_SHARED_LIBS:bool=OFF
-	execute make -j $MJOBS
-	execute make install
+  download "https://github.com/uclouvain/openjpeg/archive/v2.3.1.tar.gz" "openjpeg-v2.3.1.tar.gz"
+  make_dir build
+  cd build || exit
+  execute cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DBUILD_SHARED_LIBS:bool=OFF
+  execute make -j $MJOBS
+  execute make install
 
-	build_done "openjpeg"
+  build_done "openjpeg"
 fi
 CONFIGURE_OPTIONS+=("--enable-libopenjpeg")
 
@@ -719,28 +719,28 @@ if build "libsdl"; then
 fi
 
 if build "snappy"; then
-	download "https://github.com/google/snappy/archive/1.1.8.tar.gz"
-	make_dir build
-	cd build || exit
-	execute cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DBUILD_SHARED_LIBS:bool=OFF
-	execute make -j $MJOBS
+  download "https://github.com/google/snappy/archive/1.1.8.tar.gz"
+  make_dir build
+  cd build || exit
+  execute cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DBUILD_SHARED_LIBS:bool=OFF
+  execute make -j $MJOBS
 
-	set_mac_install_name "libsnappy.1.1.8.dylib" "libsnappy.1.dylib"
+  set_mac_install_name "libsnappy.1.1.8.dylib" "libsnappy.1.dylib"
 
-	execute make install
+  execute make install
 
-	build_done "srt"
-	build_done "snappy"
+  build_done "srt"
+  build_done "snappy"
 fi
 CONFIGURE_OPTIONS+=("--enable-libsnappy")
 
 if build "xz"; then
-	download "https://tukaani.org/xz/xz-5.2.5.tar.gz"
-	execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
-	execute make -j $MJOBS
-	execute make install
+  download "https://tukaani.org/xz/xz-5.2.5.tar.gz"
+  execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
+  execute make -j $MJOBS
+  execute make install
 
-	build_done "xz"
+  build_done "xz"
 fi
 
 ##
@@ -801,26 +801,26 @@ download "https://git.ffmpeg.org/gitweb/ffmpeg.git/snapshot/553eb0773763798a6b96
   --extra-libs="${EXTRALIBS}" \
   --pkgconfigdir="$WORKSPACE/lib/pkgconfig" \
   --pkg-config-flags="--static" \
-	--prefix="${WORKSPACE}"
+  --prefix="${WORKSPACE}"
 
 if is_mac; then
-	execute dsymutil libavcodec/libavcodec.dylib -o libavcodec.dSYM
-	execute dsymutil libavdevice/libavdevice.dylib -o libavdevice.dSYM
-	execute dsymutil libavfilter/libavfilter.dylib -o libavfilter.dSYM
-	execute dsymutil libavformat/libavformat.dylib -o libavformat.dSYM
-	# we're not building this one (libswresample replaces this)
-	# execute dsymutil libavresample/libavresample.dylib -o libavresample.dSYM
-	execute dsymutil libavutil/libavutil.dylib -o libavutil.dSYM
-	execute dsymutil libpostproc/libpostproc.dylib -o libpostproc.dSYM
-	execute dsymutil libswresample/libswresample.dylib -o libswresample.dSYM
-	execute dsymutil libswscale/libswscale.dylib -o libswscale.dSYM
+  execute dsymutil libavcodec/libavcodec.dylib -o libavcodec.dSYM
+  execute dsymutil libavdevice/libavdevice.dylib -o libavdevice.dSYM
+  execute dsymutil libavfilter/libavfilter.dylib -o libavfilter.dSYM
+  execute dsymutil libavformat/libavformat.dylib -o libavformat.dSYM
+  # we're not building this one (libswresample replaces this)
+  # execute dsymutil libavresample/libavresample.dylib -o libavresample.dSYM
+  execute dsymutil libavutil/libavutil.dylib -o libavutil.dSYM
+  execute dsymutil libpostproc/libpostproc.dylib -o libpostproc.dSYM
+  execute dsymutil libswresample/libswresample.dylib -o libswresample.dSYM
+  execute dsymutil libswscale/libswscale.dylib -o libswscale.dSYM
 fi
 
 if [[ -n "$SENTRY_AUTH_TOKEN" ]] && [[ -n "$SENTRY_ORG" ]] && [[ -n "$SENTRY_PROJECT" ]]; then
-	# TODO: install sentry-cli when running on CI
-	# reads SENTRY_AUTH_TOKEN, SENTRY_ORG and SENTRY_PROJECT from env
-	# https://docs.sentry.io/product/cli/configuration/#configuration-values
-	sentry-cli upload-dif .
+  # TODO: install sentry-cli when running on CI
+  # reads SENTRY_AUTH_TOKEN, SENTRY_ORG and SENTRY_PROJECT from env
+  # https://docs.sentry.io/product/cli/configuration/#configuration-values
+  sentry-cli upload-dif .
 fi
 
 # strip symbols from binaries (i.e., make them smaller)
@@ -888,9 +888,9 @@ fi
 
 cd $CWD
 if is_mac; then
-	node copy_mac_libs.js
-	cd "$WORKSPACE/mac"
-	execute zip --symlinks -r "ffmpeg-ffprobe-shared-darwin-x86_64.${VERSION}.zip" *
+  node copy_mac_libs.js
+  cd "$WORKSPACE/mac"
+  execute zip --symlinks -r "ffmpeg-ffprobe-shared-darwin-x86_64.${VERSION}.zip" *
 fi
 
 exit 0

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -405,7 +405,7 @@ fi
 CONFIGURE_OPTIONS+=("--enable-openssl")
 
 if build "meson"; then
-	execute python3 -m pip install meson ninja
+	execute pip3 install install meson ninja
 	build_done "meson"
 fi
 
@@ -550,7 +550,7 @@ if build "dav1d"; then
 	download "https://code.videolan.org/videolan/dav1d/-/archive/0.7.1/dav1d-0.7.1.tar.gz"
 	make_dir "$PACKAGES"/dav1d_build
 	cd "$PACKAGES"/dav1d_build || exit
-	execute meson --prefix="${WORKSPACE}" --default-library=static ../dav1d-0.7.1
+	execute meson --prefix="${WORKSPACE}" --libdir="${WORKSPACE}/lib" --default-library=static ../dav1d-0.7.1
 	execute ninja
 	execute ninja install
 
@@ -826,17 +826,19 @@ if [[ -n "$SENTRY_AUTH_TOKEN" ]] && [[ -n "$SENTRY_ORG" ]] && [[ -n "$SENTRY_PRO
 fi
 
 # strip symbols from binaries (i.e., make them smaller)
-execute strip -x libavcodec/libavcodec.dylib
-execute strip -x libavdevice/libavdevice.dylib
-execute strip -x libavfilter/libavfilter.dylib
-execute strip -x libavformat/libavformat.dylib
-execute strip -x libavutil/libavutil.dylib
-execute strip -x libpostproc/libpostproc.dylib
-execute strip -x libswresample/libswresample.dylib
-execute strip -x libswscale/libswscale.dylib
-execute strip -x ffmpeg
-execute strip -x ffprobe
-execute strip -x ffplay
+if is_mac; then
+    execute strip -x libavcodec/libavcodec.dylib
+    execute strip -x libavdevice/libavdevice.dylib
+    execute strip -x libavfilter/libavfilter.dylib
+    execute strip -x libavformat/libavformat.dylib
+    execute strip -x libavutil/libavutil.dylib
+    execute strip -x libpostproc/libpostproc.dylib
+    execute strip -x libswresample/libswresample.dylib
+    execute strip -x libswscale/libswscale.dylib
+    execute strip -x ffmpeg
+    execute strip -x ffprobe
+    execute strip -x ffplay
+fi
 
 execute make -j $MJOBS
 execute make install

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -4,7 +4,7 @@
 # LICENSE: https://github.com/markus-perl/ffmpeg-build-script/blob/master/LICENSE
 
 PROGNAME=$(basename "$0")
-VERSION=1.22
+VERSION=1.22.rc1
 CWD=$(pwd)
 PACKAGES="$CWD/packages"
 WORKSPACE="$CWD/workspace"
@@ -22,18 +22,32 @@ if [[ ("$(uname -m)" == "arm64") && ("$OSTYPE" == "darwin"*) ]]; then
   MACOS_M1=true
 fi
 
+is_mac () {
+	if [[ "$OSTYPE" == "darwin"* ]]; then
+		return 0
+	fi
+
+	return 1
+}
+
+# read by gcc and cmake
+# https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html
+export MACOSX_DEPLOYMENT_TARGET=10.11
+
 # Speed up the process
 # Env Var NUMJOBS overrides automatic detection
 if [[ -n "$NUMJOBS" ]]; then
   MJOBS="$NUMJOBS"
 elif [[ -f /proc/cpuinfo ]]; then
   MJOBS=$(grep -c processor /proc/cpuinfo)
-elif [[ "$OSTYPE" == "darwin"* ]]; then
+elif is_mac; then
   MJOBS=$(sysctl -n machdep.cpu.thread_count)
   CONFIGURE_OPTIONS=("--enable-videotoolbox")
 else
   MJOBS=4
 fi
+
+CONFIGURE_OPTIONS+=("--extra-version=beamcube")
 
 make_dir() {
   remove_dir "$1"
@@ -151,6 +165,13 @@ library_exists() {
   return 0
 }
 
+set_mac_install_name () {
+	local name="${2:-$1}"
+	if is_mac; then
+		execute install_name_tool -id "${WORKSPACE}/lib/$name" $1
+	fi
+}
+
 build_done() {
   touch "$PACKAGES/$1.done"
 }
@@ -206,7 +227,7 @@ while (($# > 0)); do
       cleanup
     fi
     if [[ "$1" == "--full-static" || "$1" =~ 'f' ]]; then
-      if [[ "$OSTYPE" == "darwin"* ]]; then
+      if is_mac; then
         echo "Error: A full static binary can only be build on Linux."
         exit 1
       fi
@@ -383,6 +404,11 @@ if build "openssl"; then
 fi
 CONFIGURE_OPTIONS+=("--enable-openssl")
 
+if build "meson"; then
+	execute python3 -m pip install meson ninja
+	build_done "meson"
+fi
+
 if build "cmake"; then
   download "https://cmake.org/files/v3.18/cmake-3.18.4.tar.gz"
   execute ./configure --prefix="${WORKSPACE}" --system-zlib
@@ -444,7 +470,7 @@ CONFIGURE_OPTIONS+=("--enable-libx265")
 if build "libvpx"; then
   download "https://github.com/webmproject/libvpx/archive/v1.9.0.tar.gz" "libvpx-1.9.0.tar.gz"
 
-  if [[ "$OSTYPE" == "darwin"* ]]; then
+  if is_mac; then
     echo "Applying Darwin patch"
     sed "s/,--version-script//g" build/make/Makefile >build/make/Makefile.patched
     sed "s/-Wl,--no-undefined -Wl,-soname/-Wl,-undefined,error -Wl,-install_name/g" build/make/Makefile.patched >build/make/Makefile
@@ -494,6 +520,16 @@ if build "vid_stab"; then
 fi
 CONFIGURE_OPTIONS+=("--enable-libvidstab")
 
+if build "twolame"; then
+	download "https://downloads.sourceforge.net/twolame/twolame-0.4.0.tar.gz"
+	execute ./configure --prefix="${WORKSPACE}" --enable-static --disable-shared
+	execute make -j $MJOBS
+	execute make install
+
+	build_done "twolame"
+fi
+CONFIGURE_OPTIONS+=("--enable-libtwolame")
+
 if build "av1"; then
   download "https://aomedia.googlesource.com/aom/+archive/b52ee6d44adaef8a08f6984390de050d64df9faa.tar.gz" "av1.tar.gz" "av1"
   make_dir "$PACKAGES"/aom_build
@@ -509,6 +545,29 @@ if build "av1"; then
   build_done "av1"
 fi
 CONFIGURE_OPTIONS+=("--enable-libaom")
+
+if build "dav1d"; then
+	download "https://code.videolan.org/videolan/dav1d/-/archive/0.7.1/dav1d-0.7.1.tar.gz"
+	make_dir "$PACKAGES"/dav1d_build
+	cd "$PACKAGES"/dav1d_build || exit
+	execute meson --prefix="${WORKSPACE}" --default-library=static ../dav1d-0.7.1
+	execute ninja
+	execute ninja install
+
+	build_done "dav1d"
+fi
+CONFIGURE_OPTIONS+=("--enable-libdav1d")
+
+if build "zimg"; then
+	download "https://github.com/sekrit-twc/zimg/archive/release-3.0.1.tar.gz"
+	execute autoreconf -i
+	execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
+	execute make -j $MJOBS
+	execute make install
+
+	build_done "zimg"
+fi
+CONFIGURE_OPTIONS+=("--enable-libzimg")
 
 ##
 ## audio library
@@ -585,6 +644,39 @@ if build "fdk_aac"; then
 fi
 CONFIGURE_OPTIONS+=("--enable-libfdk-aac")
 
+if build "shine"; then
+	download "https://github.com/toots/shine/archive/3.1.1.tar.gz" "shine-3.1.1.tar.gz"
+	execute autoreconf -i
+	execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
+	execute make -j $MJOBS
+	execute make install
+
+	build_done "shine"
+fi
+CONFIGURE_OPTIONS+=("--enable-libshine")
+
+if build "soxr"; then
+	download "http://ftp.debian.org/debian/pool/main/libs/libsoxr/libsoxr_0.1.3.orig.tar.xz" "soxr-0.1.3.tar.xz"
+	make_dir build
+	cd build || exit
+	execute cmake .. -DWITH_OPENMP:BOOL=OFF -Wno-dev -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS:BOOL=OFF
+	execute make -j $MJOBS
+	execute make install
+
+	build_done "soxr"
+fi
+CONFIGURE_OPTIONS+=("--enable-libsoxr")
+
+if build "speex"; then
+	download "http://downloads.us.xiph.org/releases/speex/speex-1.2.0.tar.gz"
+	execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
+	execute make -j $MJOBS
+	execute make install
+
+	build_done "speex"
+fi
+CONFIGURE_OPTIONS+=("--enable-libspeex")
+
 ##
 ## image library
 ##
@@ -601,6 +693,18 @@ if build "libwebp"; then
 fi
 CONFIGURE_OPTIONS+=("--enable-libwebp")
 
+if build "openjpeg"; then
+	download "https://github.com/uclouvain/openjpeg/archive/v2.3.1.tar.gz" "openjpeg-v2.3.1.tar.gz"
+	make_dir build
+	cd build || exit
+	execute cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DBUILD_SHARED_LIBS:bool=OFF
+	execute make -j $MJOBS
+	execute make install
+
+	build_done "openjpeg"
+fi
+CONFIGURE_OPTIONS+=("--enable-libopenjpeg")
+
 ##
 ## other library
 ##
@@ -614,21 +718,30 @@ if build "libsdl"; then
   build_done "libsdl"
 fi
 
-if build "srt"; then
-  download "https://github.com/Haivision/srt/archive/v1.4.1.tar.gz" "srt-1.4.1.tar.gz"
-  export OPENSSL_ROOT_DIR="${WORKSPACE}"
-  export OPENSSL_LIB_DIR="${WORKSPACE}"/lib
-  export OPENSSL_INCLUDE_DIR="${WORKSPACE}"/include/
-  execute cmake . -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_INSTALL_BINDIR=bin -DCMAKE_INSTALL_INCLUDEDIR=include -DENABLE_SHARED=OFF -DENABLE_STATIC=ON -DENABLE_APPS=OFF -DUSE_STATIC_LIBSTDCXX=ON
-  execute make install
+if build "snappy"; then
+	download "https://github.com/google/snappy/archive/1.1.8.tar.gz"
+	make_dir build
+	cd build || exit
+	execute cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DBUILD_SHARED_LIBS:bool=OFF
+	execute make -j $MJOBS
 
-  if [ -n "$LDEXEFLAGS" ]; then
-    sed -i.backup 's/-lgcc_s/-lgcc_eh/g' "${WORKSPACE}"/lib/pkgconfig/srt.pc # The -i.backup is intended and required on MacOS: https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux
-  fi
+	set_mac_install_name "libsnappy.1.1.8.dylib" "libsnappy.1.dylib"
 
-  build_done "srt"
+	execute make install
+
+	build_done "srt"
+	build_done "snappy"
 fi
-CONFIGURE_OPTIONS+=("--enable-libsrt")
+CONFIGURE_OPTIONS+=("--enable-libsnappy")
+
+if build "xz"; then
+	download "https://tukaani.org/xz/xz-5.2.5.tar.gz"
+	execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
+	execute make -j $MJOBS
+	execute make install
+
+	build_done "xz"
+fi
 
 ##
 ## HWaccel library
@@ -681,7 +794,6 @@ download "https://git.ffmpeg.org/gitweb/ffmpeg.git/snapshot/553eb0773763798a6b96
   --enable-nonfree \
   --enable-pthreads \
   --enable-static \
-  --enable-small \
   --enable-version3 \
   --extra-cflags="${CFLAGS}" \
   --extra-ldexeflags="${LDEXEFLAGS}" \
@@ -689,13 +801,48 @@ download "https://git.ffmpeg.org/gitweb/ffmpeg.git/snapshot/553eb0773763798a6b96
   --extra-libs="${EXTRALIBS}" \
   --pkgconfigdir="$WORKSPACE/lib/pkgconfig" \
   --pkg-config-flags="--static" \
-  --prefix="${WORKSPACE}"
+	--prefix="${WORKSPACE}" \
+	--disable-stripping \
+	--enable-debug
+
+if is_mac; then
+	execute dsymutil libavcodec/libavcodec.dylib -o libavcodec.dSYM
+	execute dsymutil libavdevice/libavdevice.dylib -o libavdevice.dSYM
+	execute dsymutil libavfilter/libavfilter.dylib -o libavfilter.dSYM
+	execute dsymutil libavformat/libavformat.dylib -o libavformat.dSYM
+	# we're not building this one (libswresample replaces this)
+	# execute dsymutil libavresample/libavresample.dylib -o libavresample.dSYM
+	execute dsymutil libavutil/libavutil.dylib -o libavutil.dSYM
+	execute dsymutil libpostproc/libpostproc.dylib -o libpostproc.dSYM
+	execute dsymutil libswresample/libswresample.dylib -o libswresample.dSYM
+	execute dsymutil libswscale/libswscale.dylib -o libswscale.dSYM
+fi
+
+if [[ -n "$SENTRY_AUTH_TOKEN" ]] && [[ -n "$SENTRY_ORG" ]] && [[ -n "$SENTRY_PROJECT" ]]; then
+	# TODO: install sentry-cli when running on CI
+	# reads SENTRY_AUTH_TOKEN, SENTRY_ORG and SENTRY_PROJECT from env
+	# https://docs.sentry.io/product/cli/configuration/#configuration-values
+	sentry-cli upload-dif .
+fi
+
+# strip symbols from binaries (i.e., make them smaller)
+execute strip -x libavcodec/libavcodec.dylib
+execute strip -x libavdevice/libavdevice.dylib
+execute strip -x libavfilter/libavfilter.dylib
+execute strip -x libavformat/libavformat.dylib
+execute strip -x libavutil/libavutil.dylib
+execute strip -x libpostproc/libpostproc.dylib
+execute strip -x libswresample/libswresample.dylib
+execute strip -x libswscale/libswscale.dylib
+execute strip -x ffmpeg
+execute strip -x ffprobe
+execute strip -x ffplay
 
 execute make -j $MJOBS
 execute make install
 
 INSTALL_FOLDER="/usr/bin"
-if [[ "$OSTYPE" == "darwin"* ]]; then
+if is_mac; then
   INSTALL_FOLDER="/usr/local/bin"
 fi
 
@@ -737,6 +884,13 @@ elif [[ ! "$SKIPINSTALL" == "yes" ]]; then
     echo "Done. FFmpeg is now installed to your system."
     ;;
   esac
+fi
+
+cd $CWD
+if is_mac; then
+	node copy_mac_libs.js
+	cd "$WORKSPACE/mac"
+	execute zip --symlinks -r "ffmpeg-ffprobe-shared-darwin-x86_64.${VERSION}.zip" *
 fi
 
 exit 0

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -894,7 +894,7 @@ if build "snappy" "1.1.8"; then
   download "https://github.com/google/snappy/archive/1.1.8.tar.gz"
   make_dir build
   cd build || exit
-  execute cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DBUILD_SHARED_LIBS:bool=OFF
+  execute cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${WORKSPACE}" -DBUILD_SHARED_LIBS:bool=OFF -DSNAPPY_BUILD_TESTS:bool=OFF -DSNAPPY_BUILD_BENCHMARKS:bool=OFF
   execute make -j $MJOBS
 
   set_mac_install_name "libsnappy.1.1.8.dylib" "libsnappy.1.dylib"

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -794,18 +794,18 @@ if $NONFREE_AND_GPL; then
   CONFIGURE_OPTIONS+=("--enable-libfdk-aac")
 fi
 
-if build "shine"; then
+if build "shine" "3.1.1"; then
   download "https://github.com/toots/shine/archive/3.1.1.tar.gz" "shine-3.1.1.tar.gz"
   execute autoreconf -i
   execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
   execute make -j $MJOBS
   execute make install
 
-  build_done "shine"
+  build_done "shine" "3.1.1"
 fi
 CONFIGURE_OPTIONS+=("--enable-libshine")
 
-if build "soxr"; then
+if build "soxr" "0.1.3"; then
   download "http://ftp.debian.org/debian/pool/main/libs/libsoxr/libsoxr_0.1.3.orig.tar.xz" "soxr-0.1.3.tar.xz"
   make_dir build
   cd build || exit
@@ -813,17 +813,17 @@ if build "soxr"; then
   execute make -j $MJOBS
   execute make install
 
-  build_done "soxr"
+  build_done "soxr" "0.1.3"
 fi
 CONFIGURE_OPTIONS+=("--enable-libsoxr")
 
-if build "speex"; then
+if build "speex" "1.2.0"; then
   download "http://downloads.us.xiph.org/releases/speex/speex-1.2.0.tar.gz"
   execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
   execute make -j $MJOBS
   execute make install
 
-  build_done "speex"
+  build_done "speex" "1.2.0"
 fi
 CONFIGURE_OPTIONS+=("--enable-libspeex")
 
@@ -901,8 +901,7 @@ if build "snappy" "1.1.8"; then
 
   execute make install
 
-  build_done "srt"
-  build_done "snappy"
+  build_done "snappy" "1.1.8"
 fi
 CONFIGURE_OPTIONS+=("--enable-libsnappy")
 

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -15,7 +15,7 @@ LDEXEFLAGS=""
 EXTRALIBS="-ldl -lpthread -lm -lz"
 MACOS_M1=false
 CONFIGURE_OPTIONS=()
-NONFREE_AND_GPL=false
+NONFREE_AND_GPL=true
 LATEST=false
 
 # Check for Apple Silicon
@@ -379,19 +379,6 @@ if build "m4" "1.4.19"; then
   execute make -j $MJOBS
   execute make install
   build_done "m4" "1.4.19"
-fi
-
-if build "meson" "0.0.0"; then
-  execute pip3 install install meson ninja
-  build_done "meson" "0.0.0"
-fi
-
-if build "cmake" "3.18.4"; then
-  download "https://cmake.org/files/v3.18/cmake-3.18.4.tar.gz"
-  execute ./configure --prefix="${WORKSPACE}" --system-zlib
-  execute make -j $MJOBS
-  execute make install
-  build_done "cmake" "3.18.4"
 fi
 
 if build "autoconf" "2.71"; then

--- a/full-static.dockerfile
+++ b/full-static.dockerfile
@@ -5,7 +5,7 @@ ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 
 RUN apt-get update \
-    && apt-get -y --no-install-recommends install build-essential curl ca-certificates python3 python-is-python3 python3-pip autoconf autotools-dev automake libtool meson ninja-build \
+    && apt-get -y --no-install-recommends install build-essential curl ca-certificates python3 python3-pip python-is-python3 ninja-build meson \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* \
     && update-ca-certificates
 

--- a/full-static.dockerfile
+++ b/full-static.dockerfile
@@ -5,7 +5,7 @@ ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 
 RUN apt-get update \
-    && apt-get -y --no-install-recommends install build-essential curl ca-certificates python \
+    && apt-get -y --no-install-recommends install build-essential curl ca-certificates python python3 python3-pip autoconf autotools-dev automake libtool \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* \
     && update-ca-certificates
 

--- a/full-static.dockerfile
+++ b/full-static.dockerfile
@@ -5,7 +5,7 @@ ENV NVIDIA_VISIBLE_DEVICES all
 ENV NVIDIA_DRIVER_CAPABILITIES compute,utility,video
 
 RUN apt-get update \
-    && apt-get -y --no-install-recommends install build-essential curl ca-certificates python python3 python3-pip autoconf autotools-dev automake libtool \
+    && apt-get -y --no-install-recommends install build-essential curl ca-certificates python python3 python3-pip autoconf autotools-dev automake libtool meson \
     && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* \
     && update-ca-certificates
 

--- a/full-static.dockerfile
+++ b/full-static.dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
 WORKDIR /app
 COPY ./build-ffmpeg /app/build-ffmpeg
 
-RUN AUTOINSTALL=yes /app/build-ffmpeg --build --full-static
+RUN AUTOINSTALL=yes /app/build-ffmpeg --build --full-static --enable-gpl-and-non-free
 
 # Check shared library
 RUN ! ldd /app/workspace/bin/ffmpeg

--- a/publish-to-s3.sh
+++ b/publish-to-s3.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ $# -ne 3 ]; then
+	echo "Required arguments: BUCKET PLATFORM ARCH"
+  exit 1
+fi
+
+BUCKET=$1
+PLATFORM=$2
+ARCH=$3
+
+# rename the ffmpeg/ffprobe files
+cp build/ffmpeg "build/ffmpeg-$PLATFORM-$ARCH"
+cp build/ffprobe "build/ffprobe-$PLATFORM-$ARCH"
+
+# upload to s3
+s3cmd put "build/ffmpeg-$PLATFORM-$ARCH" "build/ffprobe-$PLATFORM-$ARCH" "s3://$BUCKET/"


### PR DESCRIPTION
Got this working with the build 

```bash
docker build --tag=descript:ffmpeg --output type=local,dest=build -f full-static.dockerfile .
```

Or, on ARM macOS, after enabling experimental features in Docker Desktop:

```bash
docker buildx build --platform linux/amd64 --tag=descript:ffmpeg --output type=local,dest=build -f full-static.dockerfile .
```

Copy the ffprobe/ffmpeg binaries from the docker image:

```bash
# find the image id in the list above (look for repository: descript, tag: ffmpeg)
docker image ls 

# create a container
docker create <IMAGE ID>


docker cp <CONTAINER ID>:ffmpeg ./build
docker cp <CONTAINER ID>:ffprobe ./build
docker rm <CONTAINER ID>
```

Then, to publish ffprobe/ffmpeg that were newly built in `build/` (in ffmpeg-ffprobe-static compatible format): 

```bash
./publish-to-s3.sh <BUCKET/PATH/TO/TAG> linux x64
```